### PR TITLE
Allow and test new dependency versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,17 +10,19 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
-        symfony-version: ['^5.1', '^6.0', '^7.0']
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        symfony-version: ['^5.1', '^6.0', '^7.0', '^8.0']
         exclude:
-          - php-version: '7.4'
-            symfony-version: '^6.0'
-          - php-version: '7.4'
-            symfony-version: '^7.0'
-          - php-version: '8.0'
-            symfony-version: '^7.0'
-          - php-version: '8.1'
-            symfony-version: '^7.0'
+          - { php-version: '7.4', symfony-version: '^6.0' }
+          - { php-version: '8.0', symfony-version: '^6.0' }
+          - { php-version: '7.4', symfony-version: '^7.0' }
+          - { php-version: '8.0', symfony-version: '^7.0' }
+          - { php-version: '8.1', symfony-version: '^7.0' }
+          - { php-version: '7.4', symfony-version: '^8.0' }
+          - { php-version: '8.0', symfony-version: '^8.0' }
+          - { php-version: '8.1', symfony-version: '^8.0' }
+          - { php-version: '8.2', symfony-version: '^8.0' }
+          - { php-version: '8.3', symfony-version: '^8.0' }
     name: >-
       ${{ matrix.php-version }} with
       sf ${{ matrix.symfony-version }}

--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,15 @@
   },
   "require": {
     "php": "^7.4 || ^8.0",
-    "symfony/http-foundation": "^5.1 || ^6.0 || ^7.0",
-    "symfony/config": "^5.1 || ^6.0 || ^7.0",
-    "symfony/dependency-injection": "^5.1 || ^6.0 || ^7.0",
-    "symfony/http-kernel": "^5.1 || ^6.0 || ^7.0"
+    "symfony/http-foundation": "^5.1 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/config": "^5.1 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/dependency-injection": "^5.1 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/http-kernel": "^5.1 || ^6.0 || ^7.0 || ^8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",
-    "symfony/framework-bundle": "^5.1 || ^6.0 || ^7.0",
-    "symfony/browser-kit": "^5.1 || ^6.0 || ^7.0",
+    "symfony/framework-bundle": "^5.1 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/browser-kit": "^5.1 || ^6.0 || ^7.0 || ^8.0",
     "squizlabs/php_codesniffer": "3.6.1",
     "phpstan/phpstan": "1.2.0"
   }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,10 @@ parameters:
       path: src/DependencyInjection/Configuration.php
       count: 1
     -
+      message: '#^PHPDoc tag @var for variable \$treeBuilder contains generic type#'
+      path: src/DependencyInjection/Configuration.php
+      count: 1
+    -
       message: '#^Method [^\s]+ has parameter [^\s]+ with no value type specified in iterable type array\.$#'
       path: src/DependencyInjection/MareinStandardHeadersCsrfExtension.php
       count: 1

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@ final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {
+        /** @var TreeBuilder<'array'> $treeBuilder */
         $treeBuilder = new TreeBuilder('marein_standard_headers_csrf');
 
         $treeBuilder->getRootNode()


### PR DESCRIPTION
Add PHP 8.5 to test pipeline, and allow `symfony:^8.0`.